### PR TITLE
Feature/consistency marker after sourcing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>

--- a/postgresql-core/pom.xml
+++ b/postgresql-core/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>

--- a/postgresql-core/pom.xml
+++ b/postgresql-core/pom.xml
@@ -85,6 +85,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/postgresql-core/src/main/java/io/axoniq/framework/postgresql/PostgresqlEventStorageEngine.java
+++ b/postgresql-core/src/main/java/io/axoniq/framework/postgresql/PostgresqlEventStorageEngine.java
@@ -129,7 +129,7 @@ public final class PostgresqlEventStorageEngine implements EventStorageEngine {
           ORDER BY global_index
           LIMIT ?;
 
-        SELECT MAX(global_index) AS last_seen
+        SELECT COALESCE(MAX(global_index), 0) AS last_seen
           FROM events;
         """;
 

--- a/postgresql-core/src/test/java/io/axoniq/framework/postgresql/StorageEngineTestSuite.java
+++ b/postgresql-core/src/test/java/io/axoniq/framework/postgresql/StorageEngineTestSuite.java
@@ -268,6 +268,25 @@ public abstract class StorageEngineTestSuite<ESE extends EventStorageEngine> {
         assertThat(marker1).isEqualTo(marker2);
     }
 
+    @Test
+    void sourcingEventsShouldReturnLatestConsistencyMarkerEvenWhenEmpty() throws Exception {
+        ConsistencyMarker marker1 = testSubject.source(SourcingCondition.conditionFor(TEST_CRITERIA), processingContext())
+            .asFlux()
+            .collectList()
+            .map(List::getLast)
+            .map(entry -> entry.getResource(ConsistencyMarker.RESOURCE_KEY))
+            .block();
+
+        ConsistencyMarker marker2 = testSubject.source(SourcingCondition.conditionFor(OTHER_CRITERIA), processingContext())
+            .asFlux()
+            .collectList()
+            .map(List::getLast)
+            .map(entry -> entry.getResource(ConsistencyMarker.RESOURCE_KEY))
+            .block();
+
+        assertThat(marker1).isEqualTo(marker2);
+    }
+
     private static void assertMarkerEntry(Entry<EventMessage> entry) {
         assertNotNull(entry.getResource(ConsistencyMarker.RESOURCE_KEY));
         assertEquals(TerminalEventMessage.INSTANCE, entry.message());


### PR DESCRIPTION
The source method in the Postgres engine will now return as final consistency marker the position of the latest event known not to match the condition when there are no further matches.  Let's say events E and G match one source condition, and D and F match another, before it would return markers like this:

        A   B   C   D   E   F   G   H   I   J
                        m       m^   

        A   B   C   D   E   F   G   H   I   J
                    m       m^
                    
The logic calculating the combined consistency marker then takes the lowest, which would be `F`.
    
However, `source` expects the marker to include all events that we're sure don't match as well when the last event that matches was found, so for both of these cases it should have returned a marker `J`:

        A   B   C   D   E   F   G   H   I   J
                        m       m           ^

        A   B   C   D   E   F   G   H   I   J
                    m       m               ^
                    
This PR fixes this by querying the `MAX(global_index)` during source operations, and using this value when there are no further matches.
